### PR TITLE
Fix iframe sanitize 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 119.0.6045.105
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/app/controllers/decidim/decidim_awesome/iframe_component/iframe_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/iframe_component/iframe_controller.rb
@@ -17,7 +17,14 @@ module Decidim
 
         def sanitize(html)
           sanitizer = Rails::Html::SafeListSanitizer.new
-          sanitizer.sanitize(html, tags: %w(iframe), attributes: ALLOWED_ATTRIBUTES)
+          partially_sanitized_html = sanitizer.sanitize(html, tags: %w(iframe), attributes: ALLOWED_ATTRIBUTES)
+
+          document = Nokogiri::HTML::DocumentFragment.parse(partially_sanitized_html)
+          document.css("iframe").each do |iframe|
+            iframe["srcdoc"] = Loofah.fragment(iframe["srcdoc"]).scrub!(:prune).to_s if iframe["srcdoc"]
+          end
+
+          document.to_s
         end
 
         def remove_margins?

--- a/spec/system/awesome_iframe_spec.rb
+++ b/spec/system/awesome_iframe_spec.rb
@@ -92,4 +92,17 @@ describe "Show awesome iframe", type: :system do
       end
     end
   end
+
+  context "when iframe code contains a script in srcdoc" do
+    let(:iframe) { '<iframe srcdoc="<script>alert(\'XSS\');</script>"></iframe>' }
+
+    it "removes the script" do
+      within ".awesome-iframe" do
+        expect(page).not_to have_selector("script")
+        expect(page).to have_selector("iframe")
+        expect(page).not_to have_text("XSS")
+        expect { page.driver.browser.switch_to.alert }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Improved sanitization of Srcdoc frames

Changes:
- [x] Implemented a sanitization process using Nokogiri and Loofah, focusing on iframes with srcdoc attributes.
- [x] Extended the existing Rails HTML SafeListSanitizer to include additional sanitization for the srcdoc content.
- [x] Added system tests
